### PR TITLE
Remove !admin alias for admin message command

### DIFF
--- a/plugins/admins.py
+++ b/plugins/admins.py
@@ -5,7 +5,6 @@ help_text = ("This command sends a free-form message to town admins. "
              "Use this when you don't have a specific action item for the admins but just want to "
              "leave them a note. Feel free to leave them a nice message.")
 
-@p.register('!admin', help_text='alias of !admins')
 @p.register('!admins', help_text=help_text)
 def admins(msg):
     output = '{} in {} says "{}"'.format(msg.nick, msg.channel, msg.arg)


### PR DESCRIPTION
This will avoid the inevitable collision when I attempt to use admin commands on minerbot and it sends a message to the admins.